### PR TITLE
feat: add btn load more products && save list categories in store;

### DIFF
--- a/frontend/src/components/filter/CatalogFilters.tsx
+++ b/frontend/src/components/filter/CatalogFilters.tsx
@@ -5,19 +5,20 @@ import { RxCross2 } from 'react-icons/rx';
 import CategoryFilter from './CategoryFilter';
 import PriceFilter from './PriceFilter';
 
-
 const CatalogFilters = (): JSX.Element => {
   return (
-    <div className="flex-[0_0_auto] flex flex-col gap-[40px] w-1/4">
-      <CategoryFilter />
-      <PriceFilter />
-      <div className="mt-[-20px] text-center">
-        <Link href="/catalog" scroll={false}>
-          <div className='flex justify-center items-center'>
-            <RxCross2 />
-            Сбросить все
-          </div>
-        </Link>
+    <div className="flex-[0_0_auto] flex flex-col w-1/4">
+      <div className="sticky flex flex-col gap-[40px] top-[20px]">
+        <CategoryFilter />
+        <PriceFilter />
+        <div className="mt-[-20px] text-center">
+          <Link href="/catalog" scroll={false}>
+            <div className="flex justify-center items-center">
+              <RxCross2 />
+              Сбросить все
+            </div>
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/filter/CategoryFilter.tsx
+++ b/frontend/src/components/filter/CategoryFilter.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { JSX } from 'react';
 
-import { useFetch } from '@/hooks/useFetch';
+import { useLoadCategories } from '@/hooks/useLoadCategories';
 import { ICategory } from '@/types';
 
 import Loader from '../Loader';
@@ -12,13 +12,8 @@ import Loader from '../Loader';
 const CategoryFilter = (): JSX.Element => {
   const params = useParams();
   const categorySlug = params?.category;
-
-  const {
-    data: categories,
-    loading,
-    error,
-  } = useFetch<ICategory[]>('http://localhost:4000/categories');
-
+  const { loading, error, categories } = useLoadCategories();
+  
   if (loading)
     return (
       <div>

--- a/frontend/src/hooks/useLoadCategories.ts
+++ b/frontend/src/hooks/useLoadCategories.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { RootState } from '@/store';
+import { setCategories } from '@/store/slices/categoriesListSlice';
+import { ICategory } from '@/types';
+
+export const useLoadCategories = (): any => {
+  const dispatch = useDispatch();
+  const categories = useSelector((state: RootState) => state.categoriesList.categories);
+  const [loading, setLoading] = useState(categories.length === 0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCategories = async (): Promise<void> => {
+      try {
+        const res = await fetch('http://localhost:4000/categories');
+        if (!res.ok) throw new Error('Ошибка при загрузке категорий');
+        const data: ICategory[] = await res.json();
+        dispatch(setCategories(data));
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (categories.length === 0) {
+      fetchCategories();
+    } else {
+      setLoading(false);
+    }
+  }, [dispatch, categories.length]);
+
+  return { loading, error, categories };
+};

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import { breadcrumbsLinksReducer } from './slices/breadcrumbsLinksSlice';
 import { cartItemsReducer } from './slices/cartItemsSlice';
+import { categoriesListReducer } from './slices/categoriesListSlice';
 import { numberProductsFoundReducer } from './slices/numberProductsFound';
 import { toggleAsideCartReducer } from './slices/toggleAsideCartSlice';
 import { toggleViewModeReducer } from './slices/toggleViewModeSlice';
@@ -15,6 +16,7 @@ export const store = configureStore({
     numberProductsFound: numberProductsFoundReducer,
     breadcrumbsLinks: breadcrumbsLinksReducer,
     toggleViewMode: toggleViewModeReducer,
+    categoriesList: categoriesListReducer,
   },
 });
 

--- a/frontend/src/store/slices/categoriesListSlice.ts
+++ b/frontend/src/store/slices/categoriesListSlice.ts
@@ -1,0 +1,25 @@
+// store/slices/categoriesListSlice.ts
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { ICategory } from '@/types';
+
+interface CategoriesListState {
+  categories: ICategory[];
+}
+
+const initialState: CategoriesListState = {
+  categories: [],
+};
+
+const categoriesListSlice = createSlice({
+  name: 'categoriesListSlice',
+  initialState,
+  reducers: {
+    setCategories(state, action: PayloadAction<ICategory[]>) {
+      state.categories = action.payload;
+    },
+  },
+});
+
+export const { setCategories } = categoriesListSlice.actions;
+export const categoriesListReducer = categoriesListSlice.reducer;


### PR DESCRIPTION
🌿 load-more-product

✨ Feature
♻️ Refac

On the page with the list of products, a button has been added to upload the remaining products. The list of categories is now stored in the store.

[ms-24]
[ms-25]

![image](https://github.com/user-attachments/assets/6e26d7f1-9ac8-4f3f-95eb-5b52b984ae3b)
